### PR TITLE
Take a wakelock when reading

### DIFF
--- a/src/main/speed-reader.ts
+++ b/src/main/speed-reader.ts
@@ -13,6 +13,34 @@ const startSpeedReader = () => {
     let speedInWPM = settings.initialSpeed;
     let interval = 60 * 1000 / settings.initialSpeed;
     let paused = false;
+    let wakeLock = {
+      take() {
+        if (this.lock || this.lockPromise) return;
+
+        this.lockPromise = navigator.wakeLock?.request();
+        this.lockPromise?.then(lock => {
+          this.lock = lock;
+          this.lockPromise = null;
+        });
+      },
+
+      drop() {
+        if (this.lock) {
+          this.clearLock();
+          return;
+        }
+
+        if (this.lockPromise) {
+          this.lockPromise.then(() => this.clearLock());
+          this.lockPromise = null; // allow overwrites by a future take()
+        }
+      },
+
+      clearLock() {
+        this.lock?.release();
+        this.lock = null; // allow overwrites by a future take()
+      }
+    };
 
     const changeSpeed = (delta: number) => {
       speedInWPM += delta;
@@ -30,13 +58,22 @@ const startSpeedReader = () => {
     const togglePause = (pause?: boolean) => {
       paused = pause !== undefined ? pause : !paused;
 
-      !paused && loop();
+      if (paused) {
+        wakeLock.drop();
+      } else {
+        wakeLock.take();
+        loop();
+      }
     }
 
+    wakeLock.take();
     renderer.initialize(settings, togglePause, changeSpeed, navigateWord);
 
     const loop = () => {
-      if (words.ended() || paused) return;
+      if (words.ended() || paused) {
+        wakeLock.drop();
+        return;
+      }
 
       const nextWord = words.next();
       renderer.render(nextWord, speedInWPM, interval);


### PR DESCRIPTION
This prevents the display from sleeping while people are reading long texts.

Happy to add a setting if desired.

Chose to not propagate the `async` nature, figured it wouldn't have much of an impact if the wakelock isn't waited on. This does mean the logic is a little more involved to handle a `take()` after a `drop()` but before the wakelock has been released, for example.